### PR TITLE
user.description存在判定をpresentに変更

### DIFF
--- a/app/views/shared/_user_status.html.erb
+++ b/app/views/shared/_user_status.html.erb
@@ -9,7 +9,7 @@
   <%= render partial: 'shared/stats', locals: {user_check: user_check} %>
 </div>
 <div class="p-1 border-top">
-  <% if user_check.description %>
+  <% if user_check.description.present? %>
     <%= user_check.description %>
   <% elsif current_user == user_check %>
     Please introduce yourself from <%= link_to "here", edit_user_registration_path, class: "badge badge-primary" %>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -22,12 +22,12 @@
 
         <div class="form-group m-3">
           <%= f.label :description %>
-            <%= f.text_area :description, class: 'form-control'%>
+            <%= f.text_area :description, class: 'form-control', autocomplete: "email"%>
         </div>
 
         <div class="form-group m-3">
           <%= f.label :email %>
-          <%= f.email_field :email, class: 'form-control', autofocus: true, autocomplete: "email" %>
+          <%= f.email_field :email, class: 'form-control', autocomplete: "email" %>
         </div>
 
         <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>


### PR DESCRIPTION
### 概要
user情報更新の際にuser.descriptionを入力しない場合でも、nilをから""に更新される。
`_user_status.html.erb`はuser.descriptionがnilか判定しているため、`""`の場合でもifの条件にマッチするように変更  

### QA
- user1のupdate実施後
```
irb(main):002:0> User.first.description
  User Load (1.8ms)  SELECT  `users`.* FROM `users` ORDER BY `users`.`id` ASC LIMIT 1
=> ""
irb(main):003:0> User.second.description
  User Load (1.2ms)  SELECT  `users`.* FROM `users` ORDER BY `users`.`id` ASC LIMIT 1 OFFSET 1
=> nil
```
